### PR TITLE
feat: make balance folder configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 cp .env.example .env
+# Update `.env` with your credentials. `BALANCE_FOLDER` should point to the
+# folder inside your Obsidian vault where balances are stored, e.g.
+# `BALANCE_FOLDER=Trading/Balances/KuCoin`
 
 📈 Usage
 Log today’s balance:

--- a/balancefetcher/.env.example
+++ b/balancefetcher/.env.example
@@ -10,4 +10,5 @@ KUCOIN_BALANCE_CURRENCY=USDT
 
 # Obsidian Vault Configuration
 OBSIDIAN_VAULT_PATH=/absolute/path/to/your/obsidian/vault
-BALANCE_FOLDER=Trading/Balances
+# Path inside your vault where balance files are saved
+BALANCE_FOLDER=Trading/Balances/KuCoin

--- a/balancefetcher/start.py
+++ b/balancefetcher/start.py
@@ -17,7 +17,7 @@ api_secret = os.getenv("KUCOIN_API_SECRET")
 api_passphrase = os.getenv("KUCOIN_API_PASSPHRASE")
 currency = os.getenv("KUCOIN_BALANCE_CURRENCY", "USDT")
 vault_path = os.getenv("OBSIDIAN_VAULT_PATH")
-balance_folder = "Trading/Balances/KuCoin"
+balance_folder = os.getenv("BALANCE_FOLDER", "Trading/Balances/KuCoin")
 cache_file = os.path.expanduser("~/.kucoin_balance_log.json")
 
 # === CLI args ===


### PR DESCRIPTION
## Summary
- allow configuring balance output folder via `BALANCE_FOLDER` env var
- document expected `BALANCE_FOLDER` structure and example
- clarify `.env` configuration template

## Testing
- `python -m py_compile balancefetcher/start.py`


------
https://chatgpt.com/codex/tasks/task_e_68909018aa488332a475e5686d15e692