### PR TITLE
Validate required environment variables

### DIFF
--- a/balancefetcher/start.py
+++ b/balancefetcher/start.py
@@ -20,6 +20,19 @@ vault_path = os.getenv("OBSIDIAN_VAULT_PATH")
 balance_folder = "Trading/Balances/KuCoin"
 cache_file = os.path.expanduser("~/.kucoin_balance_log.json")
 
+# Ensure all required environment variables are present
+required_env = {
+    "KUCOIN_API_KEY": api_key,
+    "KUCOIN_API_SECRET": api_secret,
+    "KUCOIN_API_PASSPHRASE": api_passphrase,
+    "OBSIDIAN_VAULT_PATH": vault_path,
+}
+missing = [name for name, value in required_env.items() if not value]
+if missing:
+    raise SystemExit(
+        f"Missing required environment variables: {', '.join(missing)}"
+    )
+
 # === CLI args ===
 parser = argparse.ArgumentParser()
 parser.add_argument("--date", help="Override date for backfill (YYYY-MM-DD)")


### PR DESCRIPTION
## Summary
- ensure KUCOIN_API_KEY, KUCOIN_API_SECRET, KUCOIN_API_PASSPHRASE, and OBSIDIAN_VAULT_PATH are set before running

## Testing
- `python -m py_compile balancefetcher/start.py`
- `python balancefetcher/start.py --date 2024-01-01` (fails with missing variable message)


------
https://chatgpt.com/codex/tasks/task_e_68909018cf8c8332ac421150d3231351