### PR TITLE
Add configurable retry logic for balance fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Fetches your **KuCoin Futures account balance** and logs it daily into a Markdow
 - ✅ Computes daily PnL delta
 - ✅ Supports manual backfilling via `--date YYYY-MM-DD`
 - ✅ Configurable request timeout via `KUCOIN_API_TIMEOUT` (default 10s)
+- ✅ Retry logic configurable via `KUCOIN_API_MAX_RETRIES` and `KUCOIN_API_RETRY_WAIT`
 
 ---
 


### PR DESCRIPTION
## Summary
- Retry KuCoin balance requests with configurable attempts and delay
- Handle request failures with clear errors
- Document retry environment variables and test retry behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890da8621ec833287992e09b8bcc368