### PR TITLE
refactor: introduce configuration dataclass

### DIFF
--- a/balancefetcher/start.py
+++ b/balancefetcher/start.py
@@ -1,211 +1,63 @@
-import requests
+"""Command line tool to log KuCoin Futures balances."""
+
+from __future__ import annotations
+
+import argparse
 import base64
 import hashlib
 import hmac
-import time
-import os
 import json
-import argparse
 import logging
+import os
+import time
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from dotenv import load_dotenv
-import yaml
 from typing import Optional
 
-# === Logging ===
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s: %(message)s",
-)
+import requests
+import yaml
+from dotenv import load_dotenv
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Config:
+    """Runtime configuration for balance logging."""
+
+    api_key: str
+    api_secret: str
+    api_passphrase: str
+    currency: str = "USDT"
+    vault_path: str = ""
+    balance_folder: str = "Trading/Balances/KuCoin"
+    cache_file: str = field(
+        default_factory=lambda: os.path.expanduser("~/.kucoin_balance_log.json")
+    )
+    api_timeout: float = 10.0
+    api_max_retries: int = 3
+    api_retry_wait: float = 1.0
+    today: str = field(
+        default_factory=lambda: datetime.today().strftime("%Y-%m-%d")
+    )
+
+
 logger = logging.getLogger(__name__)
- 
-api_key = ""
-api_secret = ""
-api_passphrase = ""
-currency = "USDT"
-vault_path = ""
-balance_folder = "Trading/Balances/KuCoin"
-cache_file = os.path.expanduser("~/.kucoin_balance_log.json")
-api_timeout = 10.0
-api_max_retries = 3
-api_retry_wait = 1.0
-today: Optional[str] = None
 
-# === KuCoin auth ===
-def kucoin_futures_headers(endpoint: str, method: str = "GET") -> dict[str, str]:
-    """Create authenticated headers for the KuCoin Futures API.
 
-    Parameters
-    ----------
-    endpoint:
-        The API path being requested.
-    method:
-        HTTP method used for the request. Defaults to ``"GET"``.
+def setup_logging() -> None:
+    """Configure application wide logging."""
 
-    Returns
-    -------
-    dict[str, str]
-        A dictionary of headers containing the API key, signature and
-        other required authentication fields.
-    """
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 
-    now = str(int(time.time() * 1000))
-    str_to_sign = f"{now}{method}{endpoint}"
-    signature = base64.b64encode(
-        hmac.new(api_secret.encode(), str_to_sign.encode(), hashlib.sha256).digest()
-    ).decode()
-    passphrase = base64.b64encode(
-        hmac.new(api_secret.encode(), api_passphrase.encode(), hashlib.sha256).digest()
-    ).decode()
-    return {
-        "KC-API-KEY": api_key,
-        "KC-API-SIGN": signature,
-        "KC-API-TIMESTAMP": now,
-        "KC-API-PASSPHRASE": passphrase,
-        "KC-API-KEY-VERSION": "2",
-        "Content-Type": "application/json",
-    }
 
-# === Fetch balance from KuCoin Futures ===
-def fetch_futures_balance(currency: str = "USDT") -> float:
-    """Retrieve the current futures account equity for ``currency``.
-
-    Parameters
-    ----------
-    currency:
-        Currency symbol to query. Defaults to ``"USDT"``.
-
-    Returns
-    -------
-    float
-        The account equity reported by KuCoin.
-    """
-
-    endpoint = f"/api/v1/account-overview?currency={currency}"
-    url = "https://api-futures.kucoin.com" + endpoint
-    headers = kucoin_futures_headers(endpoint)
-
-    for attempt in range(1, api_max_retries + 1):
-        try:
-            res = requests.get(url, headers=headers, timeout=api_timeout)
-            res.raise_for_status()
-            return float(res.json()["data"]["accountEquity"])
-        except requests.exceptions.RequestException as e:
-            if attempt < api_max_retries:
-                logger.warning(
-                    "Request failed (attempt %s/%s): %s",
-                    attempt,
-                    api_max_retries,
-                    e,
-                )
-                time.sleep(api_retry_wait)
-            else:
-                logger.error("Failed to fetch balance after %s attempts: %s", api_max_retries, e)
-                raise RuntimeError(f"Failed to fetch balance: {e}") from e
-
-# === Read previous day's balance ===
-def read_previous_balance(date_str: str) -> float:
-    """Read the balance for the day before ``date_str`` from the vault.
-
-    If no file exists for the previous day, a placeholder file is created
-    with a balance of ``0.00``.
-
-    Parameters
-    ----------
-    date_str:
-        Target date in ``YYYY-MM-DD`` format.
-
-    Returns
-    -------
-    float
-        The balance recorded for the previous day or ``0.00`` if missing.
-    """
-
-    prev_date = (datetime.strptime(date_str, "%Y-%m-%d") - timedelta(days=1)).strftime("%Y-%m-%d")
-    file_path = os.path.join(vault_path, balance_folder, f"{prev_date}.md")
-    if not os.path.exists(file_path):
-        logger.info("🆕 No data for %s — creating placeholder.", prev_date)
-        os.makedirs(os.path.dirname(file_path), exist_ok=True)
-        with open(file_path, "w") as f:
-            f.write(f"---\ndate: {prev_date}\nbalance: 0.00\n---\n")
-        return 0.00
-    with open(file_path, "r") as f:
-        content = f.read()
-    try:
-        if content.startswith("---"):
-            parts = content.split("---", 2)
-            yaml_content = parts[1] if len(parts) > 1 else content
-        else:
-            yaml_content = content
-        data = yaml.safe_load(yaml_content) or {}
-        return float(data.get("balance", 0.00))
-    except (yaml.YAMLError, ValueError, TypeError, AttributeError) as e:
-        logger.warning("Failed to parse balance file %s: %s", file_path, e)
-        return 0.00
-    except Exception as e:
-        logger.exception("Unexpected error reading balance file %s: %s", file_path, e)
-        raise
-
-# === Write balance for a specific date ===
-def write_balance(date_str: str, balance: float) -> None:
-    """Write ``balance`` for ``date_str`` to the vault markdown file."""
-
-    file_path = os.path.join(vault_path, balance_folder, f"{date_str}.md")
-    os.makedirs(os.path.dirname(file_path), exist_ok=True)
-    with open(file_path, "w") as f:
-        f.write(f"---\ndate: {date_str}\nbalance: {balance:.2f}\n---\n")
-    logger.info("✅ Logged balance for %s: %.2f", date_str, balance)
-
-# === Cache control ===
-def already_logged(date_str: str) -> bool:
-    """Return ``True`` if ``date_str`` has already been logged today."""
-
-    if date_str != today:
-        return False
-    if not os.path.exists(cache_file):
-        return False
-    try:
-        with open(cache_file, "r") as f:
-            data = json.load(f)
-        return data.get("last_logged_date") == date_str
-    except (OSError, json.JSONDecodeError, AttributeError) as e:
-        logger.warning("Failed to read cache file %s: %s", cache_file, e)
-        return False
-    except Exception as e:
-        logger.exception("Unexpected error accessing cache file %s: %s", cache_file, e)
-        raise
-
-def mark_logged(date_str: str) -> None:
-    """Record in the cache file that ``date_str`` has been logged."""
-
-    if date_str != today:
-        return
-    with open(cache_file, "w") as f:
-        json.dump({"last_logged_date": date_str}, f)
- 
-
-# === Main ===
-def main(argv: Optional[list[str]] = None) -> None:
-    """Command line entry point for balance logging.
-
-    Parameters
-    ----------
-    argv:
-        Optional sequence of CLI arguments. If ``None`` (the default), values
-        from :data:`sys.argv` are used. This indirection allows the function to
-        be invoked programmatically during testing without triggering argument
-        parsing on import.
-    """
-
-    global api_key, api_secret, api_passphrase, currency, vault_path
-    global balance_folder, cache_file, api_timeout, api_max_retries, api_retry_wait, today
+def load_config() -> Config:
+    """Load configuration from environment variables."""
 
     load_dotenv()
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--date", help="Override date for backfill (YYYY-MM-DD)")
-    args = parser.parse_args(argv)
-
     api_key = os.getenv("KUCOIN_API_KEY", "")
     api_secret = os.getenv("KUCOIN_API_SECRET", "")
     api_passphrase = os.getenv("KUCOIN_API_PASSPHRASE", "")
@@ -229,18 +81,180 @@ def main(argv: Optional[list[str]] = None) -> None:
             f"Missing required environment variables: {', '.join(missing)}"
         )
 
-    today = datetime.today().strftime("%Y-%m-%d")
-    target_date = args.date if args.date else today
+    return Config(
+        api_key=api_key,
+        api_secret=api_secret,
+        api_passphrase=api_passphrase,
+        currency=currency,
+        vault_path=vault_path,
+        balance_folder=balance_folder,
+        cache_file=cache_file,
+        api_timeout=api_timeout,
+        api_max_retries=api_max_retries,
+        api_retry_wait=api_retry_wait,
+    )
 
-    if already_logged(target_date):
+
+# ---------------------------------------------------------------------------
+# KuCoin API helpers
+# ---------------------------------------------------------------------------
+
+
+def kucoin_futures_headers(config: Config, endpoint: str, method: str = "GET") -> dict[str, str]:
+    """Create authenticated headers for the KuCoin Futures API."""
+
+    now = str(int(time.time() * 1000))
+    str_to_sign = f"{now}{method}{endpoint}"
+    signature = base64.b64encode(
+        hmac.new(config.api_secret.encode(), str_to_sign.encode(), hashlib.sha256).digest()
+    ).decode()
+    passphrase = base64.b64encode(
+        hmac.new(config.api_secret.encode(), config.api_passphrase.encode(), hashlib.sha256).digest()
+    ).decode()
+    return {
+        "KC-API-KEY": config.api_key,
+        "KC-API-SIGN": signature,
+        "KC-API-TIMESTAMP": now,
+        "KC-API-PASSPHRASE": passphrase,
+        "KC-API-KEY-VERSION": "2",
+        "Content-Type": "application/json",
+    }
+
+
+def fetch_futures_balance(config: Config) -> float:
+    """Retrieve the current futures account equity for ``config.currency``."""
+
+    endpoint = f"/api/v1/account-overview?currency={config.currency}"
+    url = "https://api-futures.kucoin.com" + endpoint
+    headers = kucoin_futures_headers(config, endpoint)
+
+    for attempt in range(1, config.api_max_retries + 1):
+        try:
+            res = requests.get(url, headers=headers, timeout=config.api_timeout)
+            res.raise_for_status()
+            return float(res.json()["data"]["accountEquity"])
+        except requests.exceptions.RequestException as e:
+            if attempt < config.api_max_retries:
+                logger.warning(
+                    "Request failed (attempt %s/%s): %s",
+                    attempt,
+                    config.api_max_retries,
+                    e,
+                )
+                time.sleep(config.api_retry_wait)
+            else:
+                logger.error(
+                    "Failed to fetch balance after %s attempts: %s",
+                    config.api_max_retries,
+                    e,
+                )
+                raise RuntimeError(f"Failed to fetch balance: {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# Vault file helpers
+# ---------------------------------------------------------------------------
+
+
+def read_previous_balance(config: Config, date_str: str) -> float:
+    """Read the balance for the day before ``date_str`` from the vault."""
+
+    prev_date = (datetime.strptime(date_str, "%Y-%m-%d") - timedelta(days=1)).strftime("%Y-%m-%d")
+    file_path = os.path.join(config.vault_path, config.balance_folder, f"{prev_date}.md")
+    if not os.path.exists(file_path):
+        logger.info("🆕 No data for %s — creating placeholder.", prev_date)
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        with open(file_path, "w") as f:
+            f.write(f"---\ndate: {prev_date}\nbalance: 0.00\n---\n")
+        return 0.00
+    with open(file_path, "r") as f:
+        content = f.read()
+    try:
+        if content.startswith("---"):
+            parts = content.split("---", 2)
+            yaml_content = parts[1] if len(parts) > 1 else content
+        else:
+            yaml_content = content
+        data = yaml.safe_load(yaml_content) or {}
+        return float(data.get("balance", 0.00))
+    except (yaml.YAMLError, ValueError, TypeError, AttributeError) as e:
+        logger.warning("Failed to parse balance file %s: %s", file_path, e)
+        return 0.00
+    except Exception as e:
+        logger.exception("Unexpected error reading balance file %s: %s", file_path, e)
+        raise
+
+
+def write_balance(config: Config, date_str: str, balance: float) -> None:
+    """Write ``balance`` for ``date_str`` to the vault markdown file."""
+
+    file_path = os.path.join(config.vault_path, config.balance_folder, f"{date_str}.md")
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    with open(file_path, "w") as f:
+        f.write(f"---\ndate: {date_str}\nbalance: {balance:.2f}\n---\n")
+    logger.info("✅ Logged balance for %s: %.2f", date_str, balance)
+
+
+# ---------------------------------------------------------------------------
+# Cache control
+# ---------------------------------------------------------------------------
+
+
+def already_logged(config: Config, date_str: str) -> bool:
+    """Return ``True`` if ``date_str`` has already been logged today."""
+
+    if date_str != config.today:
+        return False
+    if not os.path.exists(config.cache_file):
+        return False
+    try:
+        with open(config.cache_file, "r") as f:
+            data = json.load(f)
+        return data.get("last_logged_date") == date_str
+    except (OSError, json.JSONDecodeError, AttributeError) as e:
+        logger.warning("Failed to read cache file %s: %s", config.cache_file, e)
+        return False
+    except Exception as e:
+        logger.exception("Unexpected error accessing cache file %s: %s", config.cache_file, e)
+        raise
+
+
+def mark_logged(config: Config, date_str: str) -> None:
+    """Record in the cache file that ``date_str`` has been logged."""
+
+    if date_str != config.today:
+        return
+    with open(config.cache_file, "w") as f:
+        json.dump({"last_logged_date": date_str}, f)
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    """Command line entry point for balance logging."""
+
+    setup_logging()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--date", help="Override date for backfill (YYYY-MM-DD)")
+    args = parser.parse_args(argv)
+
+    config = load_config()
+
+    target_date = args.date if args.date else config.today
+
+    if already_logged(config, target_date):
         logger.warning("🟡 Already logged today — skipping.")
         return
 
     try:
-        balance = fetch_futures_balance(currency)
-        previous_balance = read_previous_balance(target_date)
-        write_balance(target_date, balance)
-        mark_logged(target_date)
+        balance = fetch_futures_balance(config)
+        previous_balance = read_previous_balance(config, target_date)
+        write_balance(config, target_date, balance)
+        mark_logged(config, target_date)
 
         change = balance - previous_balance
         pct = (change / previous_balance) * 100 if previous_balance != 0 else 0
@@ -256,6 +270,6 @@ def main(argv: Optional[list[str]] = None) -> None:
         raise
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
     main()
 

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -6,23 +6,28 @@ import logging
 import requests
 import pytest
 
-# Ensure required env vars exist before importing module
-os.environ.setdefault("KUCOIN_API_KEY", "testkey")
-os.environ.setdefault("KUCOIN_API_SECRET", "testsecret")
-os.environ.setdefault("KUCOIN_API_PASSPHRASE", "testpass")
-os.environ.setdefault("OBSIDIAN_VAULT_PATH", "/tmp")
-
-# Prevent argparse in start.py from parsing pytest arguments
+# Load the start module without executing the CLI entry point
 sys.argv = ["start.py"]
-
 spec = importlib.util.spec_from_file_location(
     "start", Path(__file__).resolve().parent.parent / "balancefetcher" / "start.py"
 )
 start = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = start
 spec.loader.exec_module(start)
 
 
-def test_fetch_futures_balance(monkeypatch):
+@pytest.fixture
+def config(tmp_path):
+    return start.Config(
+        api_key="testkey",
+        api_secret="testsecret",
+        api_passphrase="testpass",
+        vault_path=str(tmp_path),
+        cache_file=str(tmp_path / "cache.json"),
+    )
+
+
+def test_fetch_futures_balance(monkeypatch, config):
     class MockResponse:
         def json(self):
             return {"data": {"accountEquity": "123.45"}}
@@ -34,10 +39,10 @@ def test_fetch_futures_balance(monkeypatch):
         return MockResponse()
 
     monkeypatch.setattr(start.requests, "get", mock_get)
-    assert start.fetch_futures_balance("USDT") == 123.45
+    assert start.fetch_futures_balance(config) == 123.45
 
 
-def test_fetch_futures_balance_retries(monkeypatch):
+def test_fetch_futures_balance_retries(monkeypatch, config):
     class MockResponse:
         def json(self):
             return {"data": {"accountEquity": "123.45"}}
@@ -54,71 +59,66 @@ def test_fetch_futures_balance_retries(monkeypatch):
         return MockResponse()
 
     monkeypatch.setattr(start.requests, "get", mock_get)
-    monkeypatch.setattr(start, "api_max_retries", 3)
-    monkeypatch.setattr(start, "api_retry_wait", 0)
+    config.api_max_retries = 3
+    config.api_retry_wait = 0
     monkeypatch.setattr(start.time, "sleep", lambda s: None)
-    assert start.fetch_futures_balance("USDT") == 123.45
+    assert start.fetch_futures_balance(config) == 123.45
     assert attempts["n"] == 3
 
 
-def test_fetch_futures_balance_retries_fail(monkeypatch):
+def test_fetch_futures_balance_retries_fail(monkeypatch, config):
     def mock_get(url, headers, timeout=None):
         raise requests.exceptions.Timeout("timeout")
 
     monkeypatch.setattr(start.requests, "get", mock_get)
-    monkeypatch.setattr(start, "api_max_retries", 2)
-    monkeypatch.setattr(start, "api_retry_wait", 0)
+    config.api_max_retries = 2
+    config.api_retry_wait = 0
     monkeypatch.setattr(start.time, "sleep", lambda s: None)
     with pytest.raises(RuntimeError):
-        start.fetch_futures_balance("USDT")
+        start.fetch_futures_balance(config)
 
 
-def test_write_and_read_balance(tmp_path, monkeypatch):
-    monkeypatch.setattr(start, "vault_path", str(tmp_path))
+def test_write_and_read_balance(config, tmp_path):
     date = "2024-01-01"
-    start.write_balance(date, 123.45)
-    file_path = tmp_path / start.balance_folder / f"{date}.md"
+    start.write_balance(config, date, 123.45)
+    file_path = tmp_path / config.balance_folder / f"{date}.md"
     assert file_path.exists()
     assert "balance: 123.45" in file_path.read_text()
     # Read previous day's balance
-    assert start.read_previous_balance("2024-01-02") == 123.45
+    assert start.read_previous_balance(config, "2024-01-02") == 123.45
 
 
-def test_read_previous_balance_creates_placeholder(tmp_path, monkeypatch):
-    monkeypatch.setattr(start, "vault_path", str(tmp_path))
-    balance = start.read_previous_balance("2024-01-02")
-    placeholder = tmp_path / start.balance_folder / "2024-01-01.md"
+def test_read_previous_balance_creates_placeholder(config, tmp_path):
+    balance = start.read_previous_balance(config, "2024-01-02")
+    placeholder = tmp_path / config.balance_folder / "2024-01-01.md"
     assert balance == 0.0
     assert placeholder.exists()
     assert "balance: 0.00" in placeholder.read_text()
 
 
-def test_mark_and_already_logged(tmp_path, monkeypatch):
-    cache_file = tmp_path / "cache.json"
-    monkeypatch.setattr(start, "cache_file", str(cache_file))
-    monkeypatch.setattr(start, "today", "2024-01-01")
-    assert not start.already_logged("2024-01-01")
-    start.mark_logged("2024-01-01")
-    assert start.already_logged("2024-01-01")
+def test_mark_and_already_logged(config):
+    config.today = "2024-01-01"
+    assert not start.already_logged(config, "2024-01-01")
+    start.mark_logged(config, "2024-01-01")
+    assert start.already_logged(config, "2024-01-01")
 
 
-def test_read_previous_balance_invalid_yaml(tmp_path, monkeypatch, caplog):
-    monkeypatch.setattr(start, "vault_path", str(tmp_path))
+def test_read_previous_balance_invalid_yaml(config, tmp_path, caplog):
     prev_date = "2024-01-01"
-    file_path = tmp_path / start.balance_folder / f"{prev_date}.md"
+    file_path = tmp_path / config.balance_folder / f"{prev_date}.md"
     file_path.parent.mkdir(parents=True, exist_ok=True)
     file_path.write_text("---\n::not_yaml")
     with caplog.at_level(logging.WARNING):
-        balance = start.read_previous_balance("2024-01-02")
+        balance = start.read_previous_balance(config, "2024-01-02")
     assert balance == 0.0
     assert "Failed to parse balance file" in caplog.text
 
 
-def test_already_logged_invalid_json(tmp_path, monkeypatch, caplog):
+def test_already_logged_invalid_json(config, tmp_path, caplog):
     cache_file = tmp_path / "cache.json"
     cache_file.write_text("not-json")
-    monkeypatch.setattr(start, "cache_file", str(cache_file))
-    monkeypatch.setattr(start, "today", "2024-01-01")
+    config.cache_file = str(cache_file)
+    config.today = "2024-01-01"
     with caplog.at_level(logging.WARNING):
-        assert not start.already_logged("2024-01-01")
+        assert not start.already_logged(config, "2024-01-01")
     assert "Failed to read cache file" in caplog.text


### PR DESCRIPTION
## Summary
- consolidate runtime settings into a `Config` dataclass
- move logging setup into `setup_logging` called by `main`
- pass configuration object through balance and cache helpers and update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897405065848332b60581cd829f419c