### PR TITLE
fix(vault): use python-frontmatter for parsing (v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.2.1] - 2025-08-09
+### Changed
+- Use `python-frontmatter` to parse vault front matter.
+### Added
+- Tests for malformed front matter scenarios.
+
 ## [0.2.0] - 2025-08-09
 ### Added
 - Configurable cache file location via `BALANCE_CACHE_FILE` env var or `--cache-file` flag.

--- a/balancefetcher/start.py
+++ b/balancefetcher/start.py
@@ -18,6 +18,7 @@ from filelock import FileLock
 
 import requests
 import yaml
+import frontmatter
 from dotenv import load_dotenv
 
 
@@ -180,13 +181,10 @@ def read_previous_balance(config: Config, date_str: str) -> float:
     with open(file_path, "r") as f:
         content = f.read()
     try:
-        if content.startswith("---"):
-            parts = content.split("---", 2)
-            yaml_content = parts[1] if len(parts) > 1 else content
-        else:
-            yaml_content = content
-        data = yaml.safe_load(yaml_content) or {}
-        return float(data.get("balance", 0.00))
+        post = frontmatter.loads(content)
+        if not post.metadata:
+            raise yaml.YAMLError("missing or malformed front matter")
+        return float(post.metadata.get("balance", 0.00))
     except (yaml.YAMLError, ValueError, TypeError, AttributeError) as e:
         logger.warning("Failed to parse balance file %s: %s", file_path, e)
         return 0.00

--- a/docs/decisions/2025-08-09-frontmatter.md
+++ b/docs/decisions/2025-08-09-frontmatter.md
@@ -1,0 +1,12 @@
+# Use python-frontmatter for vault parsing
+
+## Context
+Manual string splitting in `read_previous_balance` was brittle and missed malformed front-matter edge cases.
+
+## Decision
+Adopt the `python-frontmatter` library to parse YAML front matter reliably.
+
+## Consequences
+- Adds a new runtime dependency.
+- Simplifies parsing logic and centralizes YAML handling.
+- Enables detection of malformed or missing front matter.

--- a/plan.md
+++ b/plan.md
@@ -1,22 +1,20 @@
 # Plan
 
 ## Goals
-- Allow cache location configuration via env var `BALANCE_CACHE_FILE` and CLI flag `--cache-file`.
-- Prevent cache corruption by using atomic writes with file locking.
-- Scaffold repository release and documentation infrastructure (CHANGELOG, CI, AGENTS).
+- Replace manual front-matter parsing in `read_previous_balance` with the `python-frontmatter` library.
+- Add tests for malformed front-matter scenarios.
 
 ## Constraints
-- Maintain compatibility with existing behavior; default cache path remains `~/.kucoin_balance_log.json`.
-- Use lightweight dependencies only.
+- Keep dependencies minimal.
+- Preserve existing balance file format and behavior.
 
 ## Risks
-- Concurrent access may still fail if lock not released; ensure file locking handles contention.
-- Environment variables may override CLI unintentionally; CLI should take precedence.
+- Additional dependency may increase install time.
+- Malformed files might still bypass parsing; ensure warnings cover these cases.
 
 ## Test Plan
-- Unit tests for `mark_logged` concurrent access.
-- Tests for environment variable and CLI cache path overrides.
-- Run `pytest`.
+- `pip install -r requirements-dev.txt`
+- `pytest`
 
 ## SemVer Impact
-- Minor release: adds backwards-compatible features.
+- Patch release: internal parsing change with new tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-trading-balance-fetcher"
-version = "0.2.0"
+version = "0.2.1"
 description = "Fetches KuCoin Futures account balances and logs them to Obsidian."
 readme = "README.md"
 requires-python = ">=3.8"
@@ -15,6 +15,7 @@ dependencies = [
     "pyyaml>=6.0",
     "requests>=2.31",
     "filelock>=3.12",
+    "python-frontmatter>=1.1",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-dotenv>=1.0
 pyyaml>=6.0
 requests>=2.31
 filelock>=3.12
+python-frontmatter>=1.1

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -173,7 +173,29 @@ def test_read_previous_balance_invalid_yaml(config, tmp_path, caplog):
     prev_date = "2024-01-01"
     file_path = tmp_path / config.balance_folder / f"{prev_date}.md"
     file_path.parent.mkdir(parents=True, exist_ok=True)
-    file_path.write_text("---\n::not_yaml")
+    file_path.write_text("---\n: not_yaml\n---\n")
+    with caplog.at_level(logging.WARNING):
+        balance = start.read_previous_balance(config, "2024-01-02")
+    assert balance == 0.0
+    assert "Failed to parse balance file" in caplog.text
+
+
+def test_read_previous_balance_missing_closing_delimiter(config, tmp_path, caplog):
+    prev_date = "2024-01-01"
+    file_path = tmp_path / config.balance_folder / f"{prev_date}.md"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("---\ndate: 2024-01-01\nbalance: 1.23")
+    with caplog.at_level(logging.WARNING):
+        balance = start.read_previous_balance(config, "2024-01-02")
+    assert balance == 0.0
+    assert "Failed to parse balance file" in caplog.text
+
+
+def test_read_previous_balance_no_front_matter(config, tmp_path, caplog):
+    prev_date = "2024-01-01"
+    file_path = tmp_path / config.balance_folder / f"{prev_date}.md"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("date: 2024-01-01\nbalance: 1.23\n")
     with caplog.at_level(logging.WARNING):
         balance = start.read_previous_balance(config, "2024-01-02")
     assert balance == 0.0


### PR DESCRIPTION
### Summary
- replace manual YAML splitting with `python-frontmatter`
- cover malformed front matter cases with new tests

### SemVer
- [x] patch (bugfix)
- [ ] minor (backwards-compatible feature)
- [ ] major (breaking change)
Reason: internal parsing improvement and additional tests with no API changes.

### Checks
- [x] Updated version file(s)
- [x] Updated CHANGELOG.md
- [x] Tests/CI green
- [x] AGENTS.md synced with reality

------
https://chatgpt.com/codex/tasks/task_e_68974b0ed77c8332b4c421e861f53966