### PR TITLE
docs(readme): add deployment instructions (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+### Added
+- Document cron and systemd deployment with environment variable setup.
+
 ## [0.3.0] - 2025-08-16
 ### Added
 - Dockerfile exposing the `balancefetcher` console script.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,62 @@ For unattended daily execution, see the sample `docker-compose.yml`.
 docker compose up -d
 ```
 
+## 🛠 Deployment
+
+### Environment variables
+
+Copy the sample env file and fill in your credentials:
+
+```bash
+sudo cp .env.example /opt/balancefetcher/.env
+sudo chmod 600 /opt/balancefetcher/.env
+```
+
+The application automatically loads this file when run from `/opt/balancefetcher`.
+
+### Cron
+
+Run the fetcher daily at midnight:
+
+```cron
+0 0 * * * cd /opt/balancefetcher && /usr/bin/python3 balancefetcher/start.py >> /var/log/balancefetcher.log 2>&1
+```
+
+### systemd
+
+`/etc/systemd/system/balancefetcher.service`:
+
+```ini
+[Unit]
+Description=Obsidian Trading Balance Fetcher
+
+[Service]
+Type=oneshot
+EnvironmentFile=/opt/balancefetcher/.env
+WorkingDirectory=/opt/balancefetcher
+ExecStart=/usr/bin/python3 balancefetcher/start.py
+```
+
+`/etc/systemd/system/balancefetcher.timer`:
+
+```ini
+[Unit]
+Description=Run balancefetcher daily
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable the timer:
+
+```bash
+sudo systemctl enable --now balancefetcher.timer
+```
+
 ## 📊 Obsidian Integration
 
 ### Dataview Table (last 7 days)

--- a/plan.md
+++ b/plan.md
@@ -1,31 +1,27 @@
 # Plan
 
 ## Goals
-- Add a `Dockerfile` that installs the package and runs the `balancefetcher` console script.
-- Document Docker build/run instructions in `README.md`.
-- Provide a sample `docker-compose.yml` for daily execution.
+- Add a "Deployment" section to the README with cron and systemd examples.
+- Document environment variable setup for production hosts.
 
 ## Constraints
-- Preserve the existing Python-based workflow and dependency management.
-- Keep changes minimal and reversible.
+- Documentation only; no code changes.
+- Use minimal, reversible examples.
 
 ## Risks
-- Misconfigured volumes or env vars could prevent balance files from being written.
-- Docker image size may grow if dependencies are not pruned.
+- Misconfigured environment files could expose credentials.
+- Incorrect scheduling may lead to missed runs.
 
 ## Test Plan
-- `pip install -r requirements-dev.txt`
 - `pre-commit run --all-files`
 - `pytest`
 - `pip-audit -r requirements.lock`
-- `docker build -t balancefetcher .`
 
 ## SemVer Impact
-- Minor release: new Docker packaging is a backwards-compatible feature.
+- No version change; docs only.
 
 ## Affected Packages
-- obsidian-trading-balance-fetcher
+- obsidian-trading-balance-fetcher (documentation)
 
 ## Rollback
-- Remove `Dockerfile` and `docker-compose.yml`.
-- Revert documentation, version, and changelog updates.
+- Revert README, CHANGELOG, and plan updates.


### PR DESCRIPTION
## Summary
- document environment variable setup for production hosts
- add cron and systemd deployment examples

## Rationale
Clear deployment guidance reduces misconfiguration risk for scheduled runs.

## Semver Impact
No version change; documentation-only update.

## Test Evidence
- `pre-commit run --all-files`
- `pytest`
- `pip-audit -r requirements.lock`

## Risks
Misconfigured environment files or timers could prevent scheduled execution.

## Rollback
Revert README, CHANGELOG, and plan updates.

## Affected Packages
- obsidian-trading-balance-fetcher

## Checklist
- [x] Intake done
- [x] Plan attached
- [ ] Version bumped (docs only)
- [x] CHANGELOG updated
- [x] CI green
- [x] AGENTS/ADRs synced
- [ ] Tag plan ready (no release)


------
https://chatgpt.com/codex/tasks/task_e_68a04e7a6a308332b40a64e8afe465be