### PR TITLE
ci: audit dependencies in CI (v0.3.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,17 @@ jobs:
         run: pre-commit run --all-files
       - name: Run tests
         run: pytest
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pip-audit
+      - name: Audit dependencies
+        run: pip-audit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Install deps: `pip install -r requirements-dev.txt`
 - Run linters: `pre-commit run --all-files`
 - Run tests: `pytest`
+- Audit dependencies: `pip-audit`
 - Update version in `pyproject.toml` and `CHANGELOG.md` for code changes
 - Follow Conventional Commits
 - Build container: `docker build -t balancefetcher .`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.3.1] - 2025-08-16
 ### Added
 - Document cron and systemd deployment with environment variable setup.
+
+### Security
+- Run `pip-audit` in CI to fail on vulnerable dependencies.
 
 ## [0.3.0] - 2025-08-16
 ### Added

--- a/plan.md
+++ b/plan.md
@@ -1,27 +1,26 @@
 # Plan
 
 ## Goals
-- Add a "Deployment" section to the README with cron and systemd examples.
-- Document environment variable setup for production hosts.
+- Add a dependency vulnerability audit to CI using `pip-audit`.
 
 ## Constraints
-- Documentation only; no code changes.
-- Use minimal, reversible examples.
+- Use existing GitHub Actions workflow style.
+- Keep changes minimal and reversible.
 
 ## Risks
-- Misconfigured environment files could expose credentials.
-- Incorrect scheduling may lead to missed runs.
+- CI failures due to transient advisory database issues.
+- Increased runtime for CI jobs.
 
 ## Test Plan
 - `pre-commit run --all-files`
 - `pytest`
-- `pip-audit -r requirements.lock`
+- `pip-audit`
 
 ## SemVer Impact
-- No version change; docs only.
+- Patch release: 0.3.1
 
 ## Affected Packages
-- obsidian-trading-balance-fetcher (documentation)
+- obsidian-trading-balance-fetcher
 
 ## Rollback
-- Revert README, CHANGELOG, and plan updates.
+- Revert workflow, documentation, and version changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-trading-balance-fetcher"
-version = "0.3.0"
+version = "0.3.1"
 description = "Fetches KuCoin Futures account balances and logs them to Obsidian."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- add GitHub Actions job that installs dependencies and audits them with `pip-audit`
- document `pip-audit` usage in contributor guide
- bump version to v0.3.1 and record security job in the changelog

## Rationale
Adds automated dependency vulnerability scanning to catch insecure packages before release.

## Testing
- `pre-commit run --all-files`
- `pytest`
- `pip-audit`

## SemVer
Patch release (v0.3.1)

## Checklist
- [x] Intake done
- [x] Plan attached
- [x] Version bumped
- [x] CHANGELOG updated
- [x] CI green
- [x] AGENTS/ADRs synced
- [x] Tag plan ready

------
https://chatgpt.com/codex/tasks/task_e_68a04fc866f4833297353ff60fa90023