### PR TITLE
ci(release): generate release notes from changelog (v0.3.2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,12 @@ jobs:
             git tag -a "$TAG" -m "Release $TAG"
             git push origin "$TAG"
           fi
-      - name: Generate release notes
+      - name: Extract release notes
+        run: python scripts/generate_release_notes.py ${{ steps.v.outputs.version }}
+      - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.v.outputs.version }}
-          body_path: .github/RELEASE_NOTES.md
+          body_path: RELEASE_NOTES.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.3.2] - 2025-08-16
+### Changed
+- Generate release notes from `CHANGELOG.md` during release.
+
 ## [0.3.1] - 2025-08-16
 ### Added
 - Document cron and systemd deployment with environment variable setup.

--- a/plan.md
+++ b/plan.md
@@ -1,15 +1,15 @@
 # Plan
 
 ## Goals
-- Add a dependency vulnerability audit to CI using `pip-audit`.
+- Generate release notes from `CHANGELOG.md` during the release workflow.
 
 ## Constraints
-- Use existing GitHub Actions workflow style.
-- Keep changes minimal and reversible.
+- Follow existing GitHub Actions style and keep changes minimal.
+- Avoid persistent artifacts; release notes should be generated at runtime.
 
 ## Risks
-- CI failures due to transient advisory database issues.
-- Increased runtime for CI jobs.
+- Release workflow fails if the changelog entry for the version is missing or misformatted.
+- Incorrect parsing could produce empty release notes.
 
 ## Test Plan
 - `pre-commit run --all-files`
@@ -17,10 +17,10 @@
 - `pip-audit`
 
 ## SemVer Impact
-- Patch release: 0.3.1
+- Patch release: 0.3.2
 
 ## Affected Packages
 - obsidian-trading-balance-fetcher
 
 ## Rollback
-- Revert workflow, documentation, and version changes.
+- Revert script, workflow, version, and changelog changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-trading-balance-fetcher"
-version = "0.3.1"
+version = "0.3.2"
 description = "Fetches KuCoin Futures account balances and logs them to Obsidian."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Generate release notes for the given version from CHANGELOG.md."""
+import re
+import sys
+from pathlib import Path
+
+
+def extract_section(text: str, version: str) -> str:
+    pattern = rf"(## \[{re.escape(version)}\].*?)(?=\n## \[|\Z)"
+    match = re.search(pattern, text, re.DOTALL)
+    if not match:
+        raise SystemExit(f"Version {version} not found in changelog")
+    return match.group(1).strip() + "\n"
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: generate_release_notes.py <version> [output]")
+        raise SystemExit(1)
+    version = sys.argv[1]
+    output = Path(sys.argv[2]) if len(sys.argv) > 2 else Path("RELEASE_NOTES.md")
+    changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
+    section = extract_section(changelog, version)
+    output.write_text(section, encoding="utf-8")
+    print(f"Wrote release notes for {version} to {output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate release notes from CHANGELOG during release workflow
- script replaces static release notes file
- bump to v0.3.2

## Rationale
Automates release documentation and eliminates stale static notes.

## SemVer
Patch: CI tooling updated without impacting runtime code.

## Testing
- `pre-commit run --all-files`
- `pytest`
- `pip-audit`

## Risks
- Release could fail if changelog lacks the version header.

## Rollback
- Revert workflow, script, version, and changelog changes.

## Checklist
- [x] Intake done
- [x] Plan attached
- [x] Version bumped
- [x] CHANGELOG updated
- [x] CI green
- [x] AGENTS/ADRs synced
- [x] Tag plan ready

## Packages Affected
- obsidian-trading-balance-fetcher

------
https://chatgpt.com/codex/tasks/task_e_68a052e493688332aa9c378b577c8545