### PR TITLE
ci(release): publish tagged releases to PyPI (v0.3.3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,10 @@ name: release
 on:
   push:
     branches: [main]
+    tags: [v*]
 jobs:
   tag-and-notes:
+    if: startsWith(github.ref, 'refs/heads/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,3 +37,21 @@ jobs:
           body_path: RELEASE_NOTES.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Build wheel
+        run: |
+          python -m pip install build
+          python -m build --wheel
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - Versioning: `pyproject.toml` uses Semantic Versioning
 - Changelog: `CHANGELOG.md` in Keep a Changelog format
 - CI: GitHub Actions workflows in `.github/workflows`
-- Release: tag `v<version>` on main; changelog and version must match
+- Release: tag `v<version>` on main; changelog and version must match; tagged releases publish to PyPI using `PYPI_API_TOKEN`
 - Docker: `Dockerfile` installs the project and runs the `balancefetcher` console script
 
 ## Development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.3.3] - 2025-08-16
+### Added
+- Publish tagged releases to PyPI via GitHub Actions.
+- Document installation via `pip install obsidian-trading-balance-fetcher`.
+
 ## [0.3.2] - 2025-08-16
 ### Changed
 - Generate release notes from `CHANGELOG.md` during release.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Fetches your **KuCoin Futures account balance** and logs it daily into a Markdow
 
 ## 📦 Installation
 
+Install from PyPI:
+
+```bash
+pip install obsidian-trading-balance-fetcher
+```
+
+Or install from source:
+
 ```bash
 git clone https://github.com/c1nderscript/Obsidian-Trading-Balance-Fetcher.git
 cd Obsidian-Trading-Balance-Fetcher

--- a/plan.md
+++ b/plan.md
@@ -1,15 +1,16 @@
 # Plan
 
 ## Goals
-- Generate release notes from `CHANGELOG.md` during the release workflow.
+- Build wheel and publish to PyPI on tagged releases via GitHub Actions.
+- Document `pip install obsidian-trading-balance-fetcher` in README.
 
 ## Constraints
 - Follow existing GitHub Actions style and keep changes minimal.
-- Avoid persistent artifacts; release notes should be generated at runtime.
+- Assume `PYPI_API_TOKEN` is configured as a repository secret.
 
 ## Risks
-- Release workflow fails if the changelog entry for the version is missing or misformatted.
-- Incorrect parsing could produce empty release notes.
+- Publishing fails if the secret is missing or invalid.
+- Tagging without updating version or changelog produces incorrect releases.
 
 ## Test Plan
 - `pre-commit run --all-files`
@@ -17,10 +18,10 @@
 - `pip-audit`
 
 ## SemVer Impact
-- Patch release: 0.3.2
+- Patch release: 0.3.3
 
 ## Affected Packages
 - obsidian-trading-balance-fetcher
 
 ## Rollback
-- Revert script, workflow, version, and changelog changes.
+- Revert workflow, docs, version, and changelog changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-trading-balance-fetcher"
-version = "0.3.2"
+version = "0.3.3"
 description = "Fetches KuCoin Futures account balances and logs them to Obsidian."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- build wheel and publish to PyPI on tagged releases
- document `pip install obsidian-trading-balance-fetcher`
- note PyPI publishing in AGENTS

## Rationale
Distributes the project through PyPI and records the installation method.

## Semver Justification
Patch: CI and documentation only; no runtime changes.

## Test Evidence
- `pre-commit run --all-files`
- `pytest`
- `pip-audit`
- `bash scripts/agents-verify.sh`

## Risks
Publishing could fail without a valid `PYPI_API_TOKEN` secret.

## Rollback
Revert this PR.

## Checklist
- [x] Intake done
- [x] Plan attached
- [x] Version bumped
- [x] CHANGELOG updated
- [x] CI green
- [x] AGENTS/ADRs synced
- [x] Tag plan ready


------
https://chatgpt.com/codex/tasks/task_e_68a059d32ae883329c93764de9bfba99