### PR TITLE
test(start): add missing env var coverage (v0.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.3.4] - 2025-08-16
+### Added
+- Test covering missing required environment variables for `load_config()`.
+
 ## [0.3.3] - 2025-08-16
 ### Added
 - Publish tagged releases to PyPI via GitHub Actions.

--- a/plan.md
+++ b/plan.md
@@ -1,16 +1,14 @@
 # Plan
 
 ## Goals
-- Build wheel and publish to PyPI on tagged releases via GitHub Actions.
-- Document `pip install obsidian-trading-balance-fetcher` in README.
+- Add a pytest case asserting `load_config()` exits with `SystemExit` when required environment variables are missing and lists all missing variables.
 
 ## Constraints
-- Follow existing GitHub Actions style and keep changes minimal.
-- Assume `PYPI_API_TOKEN` is configured as a repository secret.
+- Follow repository instructions in `AGENTS.md`.
+- Keep changes minimal and reversible.
 
 ## Risks
-- Publishing fails if the secret is missing or invalid.
-- Tagging without updating version or changelog produces incorrect releases.
+- Environment variable cleanup may affect other tests if not isolated.
 
 ## Test Plan
 - `pre-commit run --all-files`
@@ -18,10 +16,10 @@
 - `pip-audit`
 
 ## SemVer Impact
-- Patch release: 0.3.3
+- Patch release: 0.3.4
 
 ## Affected Packages
 - obsidian-trading-balance-fetcher
 
 ## Rollback
-- Revert workflow, docs, version, and changelog changes.
+- Revert the commit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-trading-balance-fetcher"
-version = "0.3.3"
+version = "0.3.4"
 description = "Fetches KuCoin Futures account balances and logs them to Obsidian."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -212,6 +212,26 @@ def test_already_logged_invalid_json(config, tmp_path, caplog):
     assert "Failed to read cache file" in caplog.text
 
 
+def test_load_config_missing_required(monkeypatch):
+    for var in [
+        "KUCOIN_API_KEY",
+        "KUCOIN_API_SECRET",
+        "KUCOIN_API_PASSPHRASE",
+        "OBSIDIAN_VAULT_PATH",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(SystemExit) as exc:
+        start.load_config()
+    msg = str(exc.value)
+    for var in [
+        "KUCOIN_API_KEY",
+        "KUCOIN_API_SECRET",
+        "KUCOIN_API_PASSPHRASE",
+        "OBSIDIAN_VAULT_PATH",
+    ]:
+        assert var in msg
+
+
 def test_load_config_cache_file_env(monkeypatch, tmp_path):
     monkeypatch.setenv("KUCOIN_API_KEY", "k")
     monkeypatch.setenv("KUCOIN_API_SECRET", "s")


### PR DESCRIPTION
## Summary
- add regression test for `load_config()` that exits with `SystemExit` and lists missing required environment variables
- bump version to 0.3.4 and document the change

## Rationale
Ensure missing configuration is detected with a clear error message.

## SemVer
Patch release: adds tests without changing runtime behavior.

## Testing
- `pre-commit run --all-files`
- `pytest`
- `pip-audit`

## Risks
Low; test-only change.

## Rollback
Revert this commit.

## Touched Packages
- obsidian-trading-balance-fetcher


------
https://chatgpt.com/codex/tasks/task_e_68a05bf9b9008332be8ed9c8097fc929