### PR TITLE
feat(logging): make log level configurable via env (0.4.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,4 @@ BALANCE_FOLDER=Trading/Balances/KuCoin  # Path in vault for balance notes
 # KUCOIN_API_TIMEOUT=10                 # Request timeout in seconds
 # KUCOIN_API_MAX_RETRIES=3              # Max retry attempts for API calls
 # KUCOIN_API_RETRY_WAIT=1               # Wait time between retries in seconds
+# LOG_LEVEL=INFO                        # Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+### Added
+- Allow configuring log verbosity via `LOG_LEVEL` environment variable.
+
 ## [0.3.4] - 2025-08-16
 ### Added
 - Test covering missing required environment variables for `load_config()`.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Fetches your **KuCoin Futures account balance** and logs it daily into a Markdow
 - ✅ Supports manual backfilling via `--date YYYY-MM-DD`
 - ✅ Configurable request timeout via `KUCOIN_API_TIMEOUT` (default 10s)
 - ✅ Retry logic configurable via `KUCOIN_API_MAX_RETRIES` and `KUCOIN_API_RETRY_WAIT`
+- ✅ Logging verbosity configurable via `LOG_LEVEL` (default `INFO`)
 
 ---
 
@@ -56,6 +57,12 @@ Optionally override the cache location:
 
 ```env
 BALANCE_CACHE_FILE=/path/to/cache.json
+```
+
+Adjust logging verbosity (default `INFO`):
+
+```env
+LOG_LEVEL=DEBUG
 ```
 
 Log today’s balance:

--- a/balancefetcher/start.py
+++ b/balancefetcher/start.py
@@ -51,10 +51,10 @@ logger = logging.getLogger(__name__)
 
 def setup_logging() -> None:
     """Configure application wide logging."""
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
 
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s"
-    )
+    logging.basicConfig(level=level, format="%(asctime)s %(levelname)s: %(message)s")
 
 
 def load_config() -> Config:

--- a/plan.md
+++ b/plan.md
@@ -1,14 +1,16 @@
 # Plan
 
 ## Goals
-- Add a pytest case asserting `load_config()` exits with `SystemExit` when required environment variables are missing and lists all missing variables.
+- Add `LOG_LEVEL` environment variable defaulting to `INFO`.
+- Modify `setup_logging()` to respect `LOG_LEVEL`.
+- Document `LOG_LEVEL` in `.env.example` and `README`.
 
 ## Constraints
 - Follow repository instructions in `AGENTS.md`.
 - Keep changes minimal and reversible.
 
 ## Risks
-- Environment variable cleanup may affect other tests if not isolated.
+- Invalid log level values could cause confusion.
 
 ## Test Plan
 - `pre-commit run --all-files`
@@ -16,10 +18,10 @@
 - `pip-audit`
 
 ## SemVer Impact
-- Patch release: 0.3.4
+- Minor release: `0.4.0`
 
 ## Affected Packages
-- obsidian-trading-balance-fetcher
+- `obsidian-trading-balance-fetcher`
 
 ## Rollback
 - Revert the commit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-trading-balance-fetcher"
-version = "0.3.4"
+version = "0.4.0"
 description = "Fetches KuCoin Futures account balances and logs them to Obsidian."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- allow configuring log verbosity via `LOG_LEVEL`
- document `LOG_LEVEL` in sample env and README

## Rationale and context
Enables adjusting logging verbosity without code changes.

## SemVer justification
Minor: adds backward-compatible functionality.

## Test evidence
- `pre-commit run --all-files`
- `pytest`
- `pip-audit`

## Risk assessment and rollback plan
Low risk; revert commit if logging behaves unexpectedly.

## Affected packages list
- obsidian-trading-balance-fetcher

## Checklist
- [x] Intake analysis complete
- [x] Plan reviewed and approved
- [x] Version files updated
- [x] CHANGELOG.md updated
- [x] CI pipeline passing
- [x] Documentation synchronized
- [x] Security audit complete
- [ ] Release tags prepared

------
https://chatgpt.com/codex/tasks/task_e_68a0633226e08332b09a836ba8baed4a