### PR TITLE
ci(release): add SBOM generation (0.4.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,18 @@ jobs:
         run: |
           python -m pip install build
           python -m build --wheel
+      - name: Generate SBOM
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+          syft dist/*.whl -o sbom.spdx.json
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Upload SBOM to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: sbom.spdx.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented here.
 
 ### Added
 - Allow configuring log verbosity via `LOG_LEVEL` environment variable.
+- Generate SBOM for the built wheel and attach it to GitHub Releases.
 
 ## [0.3.4] - 2025-08-16
 ### Added

--- a/plan.md
+++ b/plan.md
@@ -1,16 +1,17 @@
 # Plan
 
 ## Goals
-- Add `LOG_LEVEL` environment variable defaulting to `INFO`.
-- Modify `setup_logging()` to respect `LOG_LEVEL`.
-- Document `LOG_LEVEL` in `.env.example` and `README`.
+- Incorporate Syft to generate SBOM for the built wheel in the release workflow.
+- Attach the generated SBOM to GitHub Releases.
 
 ## Constraints
 - Follow repository instructions in `AGENTS.md`.
 - Keep changes minimal and reversible.
+- Preserve existing release workflow behavior.
 
 ## Risks
-- Invalid log level values could cause confusion.
+- Syft installation or execution may fail, breaking the release process.
+- Uploading assets requires the release to exist.
 
 ## Test Plan
 - `pre-commit run --all-files`
@@ -18,7 +19,7 @@
 - `pip-audit`
 
 ## SemVer Impact
-- Minor release: `0.4.0`
+- No version change (CI-only).
 
 ## Affected Packages
 - `obsidian-trading-balance-fetcher`


### PR DESCRIPTION
### Summary
- Generate an SBOM for the built wheel during releases and upload it as a release asset.
- Document SBOM generation in the changelog.

### Rationale and Context
- Ensures supply-chain transparency by providing an SBOM with each release.

### SemVer Justification
- CI-only change, no functional impact. Patch level; version remains 0.4.0.

### Test Evidence
- `pre-commit run --all-files`
- `pytest`
- `pip-audit`

### Risk Assessment and Rollback Plan
- Risk: syft installation or asset upload failure could break releases.
- Rollback: revert the commit.

### Affected Packages
- `obsidian-trading-balance-fetcher`

### Checklist
- [x] Intake analysis complete
- [x] Plan reviewed and approved
- [ ] Version files updated (n/a)
- [x] CHANGELOG.md updated
- [x] CI pipeline passing
- [x] Documentation synchronized
- [x] Security audit complete
- [x] Release tags prepared

------
https://chatgpt.com/codex/tasks/task_e_68a06826e2bc8332bf12b505b4638698